### PR TITLE
Add support for specifying bitdepth, colors, and dither in options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,10 @@ var mapSlicer = mapslice({
     tmp: "./temp",                     // (default: '.tmp') Temporary directory to be used to store helper files
     parallelLimit: 3,                  // (default: 5) Maximum parallel tasks to be run at the same time (warning: processes can consume a lot of memory!)
     minWidth: 200,                     // See explanation about Size detection below
-    skipEmptyTiles: true               // Skips all the empty tiles
+    skipEmptyTiles: true,              // Skips all the empty tiles
+    bitdepth: 8,                       // (optional) See http://aheckmann.github.io/gm/docs.html#dither
+    dither: true,                      // (optional) See http://aheckmann.github.io/gm/docs.html#bitdepth
+    colors: 128,                       // (optional) See http://aheckmann.github.io/gm/docs.html#colors
 });
 
 mapSlicer.on("start", function(files, options) {

--- a/lib/processLevel.js
+++ b/lib/processLevel.js
@@ -6,7 +6,17 @@ module.exports = function processLevel (options, level, levelFile) {
     mkdirp(path.dirname(levelFile), function (err) {
       if (err) return next(err)
       var drawCommand = 'image Over ' + level.x + ',' + level.y + ' ' + level.width + ',' + level.height + ' \'' + options.file + '\''
-      options.gm(level.size, level.size, options.background).draw(drawCommand).write(levelFile, function (err, result) {
+      var image = options.gm(level.size, level.size, options.background).draw(drawCommand)
+      if (options.hasOwnProperty('bitdepth') && typeof options.bitdepth === 'number') {
+        image.bitdepth(options.bitdepth)
+      }
+      if (options.hasOwnProperty('dither') && typeof options.dither === 'boolean') {
+        image.dither(options.dither)
+      }
+      if (options.hasOwnProperty('colors') && typeof options.colors === 'number') {
+        image.colors(options.colors)
+      }
+      image.write(levelFile, function (err, result) {
         next(err, levelFile)
       })
     })


### PR DESCRIPTION
In order to help reduce the file size of tiles, it would be very helpful if bitdepth, colors, and dither could be specified in the mapslice options.  I made these parameters optional.